### PR TITLE
학대정황 수정, 삭제 api + 조회 api에서 사진, 녹음, 동영상 인덱스 가져오도록 추가

### DIFF
--- a/src/main/java/com/save_backend/src/abuse/AbuseController.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseController.java
@@ -2,11 +2,11 @@ package com.save_backend.src.abuse;
 
 import com.save_backend.config.exception.BaseException;
 import com.save_backend.config.response.BaseResponse;
-import com.save_backend.src.abuse.model.GetAbuseRes;
-import com.save_backend.src.abuse.model.PostAbuseReq;
-import com.save_backend.src.abuse.model.PostAbuseRes;
+import com.save_backend.src.abuse.model.*;
 import com.save_backend.src.child.ChildProvider;
 import com.save_backend.src.child.ChildService;
+import com.save_backend.src.child.model.PatchChildEditReq;
+import com.save_backend.src.child.model.PatchChildEditRes;
 import com.save_backend.src.child.model.PostChildReq;
 import com.save_backend.src.child.model.PostChildRes;
 import com.save_backend.src.suspect.model.GetSuspectRes;
@@ -78,6 +78,45 @@ public class AbuseController {
         try {
             GetAbuseRes getAbuseRes = abuseProvider.getAbuseByIdx(abuseIdx);
             return new BaseResponse<>(getAbuseRes);
+        } catch (BaseException exception){
+            return new BaseResponse<>(exception.getStatus());
+        }
+    }
+
+    /**
+     * 3. 학대 정황 수정 api
+     */
+    @ResponseBody
+    @PatchMapping("/{abuseIdx}")
+    public BaseResponse<String> modifyAbuse(@PathVariable("abuseIdx") int abuseIdx, @RequestBody PatchAbuseReq patchAbuseReq){
+        // 날짜 선택 필수
+        if(patchAbuseReq.getDate() == null){
+            return new BaseResponse<>(EMPTY_ABUSE_DATE);
+        }
+        // 시간 선택 필수
+        if (patchAbuseReq.getTime() == null) {
+            return new BaseResponse<>(EMPTY_ABUSE_TIME);
+        }
+        // 장소 선택 필수
+        if (patchAbuseReq.getPlace() == null) {
+            return new BaseResponse<>(EMPTY_ABUSE_PLACE);
+        }
+        // 구체적 의심정황 입력 필수
+        if (patchAbuseReq.getDetail() == null) {
+            return new BaseResponse<>(EMPTY_ABUSE_DESCRIPTION);
+        }
+        //학대 의심자 선택 필수
+//        if (patchAbuseReq.getSuspect().size() < 1) {
+//            return new BaseResponse<>(EMPTY_SUSPECT_INDEX);
+//        }
+        // 학대유형 선택 필수
+        if (patchAbuseReq.getType().size() < 1) {
+            return new BaseResponse<>(EMPTY_ABUSE_TYPE);
+        }
+        try {
+            abuseService.modifyAbuse(abuseIdx, patchAbuseReq);
+            String editResult = "정황 수정을 완료하였습니다.";
+            return new BaseResponse<>(editResult);
         } catch (BaseException exception){
             return new BaseResponse<>(exception.getStatus());
         }

--- a/src/main/java/com/save_backend/src/abuse/AbuseController.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseController.java
@@ -5,10 +5,7 @@ import com.save_backend.config.response.BaseResponse;
 import com.save_backend.src.abuse.model.*;
 import com.save_backend.src.child.ChildProvider;
 import com.save_backend.src.child.ChildService;
-import com.save_backend.src.child.model.PatchChildEditReq;
-import com.save_backend.src.child.model.PatchChildEditRes;
-import com.save_backend.src.child.model.PostChildReq;
-import com.save_backend.src.child.model.PostChildRes;
+import com.save_backend.src.child.model.*;
 import com.save_backend.src.suspect.model.GetSuspectRes;
 import org.springframework.web.bind.annotation.*;
 
@@ -119,6 +116,20 @@ public class AbuseController {
             return new BaseResponse<>(editResult);
         } catch (BaseException exception){
             return new BaseResponse<>(exception.getStatus());
+        }
+    }
+
+    /**
+     * 4. 학대 정황 삭제 api
+     */
+    @ResponseBody
+    @PatchMapping("/status/{abuseIdx}")
+    public BaseResponse<PatchAbuseDelRes> deleteCAbuse(@PathVariable("abuseIdx") int abuseIdx) {
+        try {
+            PatchAbuseDelRes patchAbuseDelRes = abuseService.deleteAbuse(abuseIdx);
+            return new BaseResponse<>(patchAbuseDelRes);
+        } catch (BaseException exception) {
+            return new BaseResponse<>((exception.getStatus()));
         }
     }
 }

--- a/src/main/java/com/save_backend/src/abuse/AbuseController.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseController.java
@@ -102,10 +102,6 @@ public class AbuseController {
         if (patchAbuseReq.getDetail() == null) {
             return new BaseResponse<>(EMPTY_ABUSE_DESCRIPTION);
         }
-        //학대 의심자 선택 필수
-//        if (patchAbuseReq.getSuspect().size() < 1) {
-//            return new BaseResponse<>(EMPTY_SUSPECT_INDEX);
-//        }
         // 학대유형 선택 필수
         if (patchAbuseReq.getType().size() < 1) {
             return new BaseResponse<>(EMPTY_ABUSE_TYPE);

--- a/src/main/java/com/save_backend/src/abuse/AbuseDao.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseDao.java
@@ -1,6 +1,7 @@
 package com.save_backend.src.abuse;
 
 import com.save_backend.src.abuse.model.*;
+import com.save_backend.src.suspect.model.PatchSuspectReq;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -187,9 +188,9 @@ public class AbuseDao {
         int checkChildParams = childIdx;
         return this.jdbcTemplate.queryForObject(checkChildQuery,int.class,checkChildParams);
     }
-    public int checkSuspect(int suspectIdx){
+    public int checkSuspect(PatchAbuseSuspectReq patchAbuseSuspectReq){
         String checkSuspectQuery = "select exists(select suspect_idx from suspect where suspect_idx = ? and status = 'ACTIVE')";
-        int checkSuspectParams = suspectIdx;
+        int checkSuspectParams = patchAbuseSuspectReq.getSuspectIdx();
         return this.jdbcTemplate.queryForObject(checkSuspectQuery,int.class,checkSuspectParams);
     }
     public int checkAbuse(int abuseIdx){

--- a/src/main/java/com/save_backend/src/abuse/AbuseDao.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseDao.java
@@ -6,6 +6,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.util.Collections;
 import java.util.List;
 
 @Repository
@@ -13,6 +14,9 @@ public class AbuseDao {
 
     private JdbcTemplate jdbcTemplate;
     private List<GetAbuseSuspectRes> getAbuseSuspectRes;
+    private List<GetAbusePicRes> getAbusePicRes;
+    private List<GetAbuseVidRes> getAbuseVidRes;
+    private List<GetAbuseRecRes> getAbuseRecRes;
 
     @Autowired
     public void setDataSource(DataSource dataSource){
@@ -53,7 +57,7 @@ public class AbuseDao {
     }
 
     public GetAbuseRes getAbuseByIdx(int abuseIdx){
-        String getAbuseByIdxQuery = "SELECT abuse_idx, abuse_date, abuse_time, abuse_place, abuse_type, detail_description, etc\n" +
+        String getAbuseByIdxQuery = "SELECT abuse_idx, abuse_date, abuse_time, abuse_place, abuse_type, detail_description, etc, create_date\n" +
                 "FROM abuse_situation WHERE abuse_idx = ?;";
         int getAbuseByIdxParams = abuseIdx;
         return this.jdbcTemplate.queryForObject(getAbuseByIdxQuery,
@@ -65,6 +69,29 @@ public class AbuseDao {
                         rs.getString("abuse_type"),
                         rs.getString("detail_description"),
                         rs.getString("etc"),
+                        rs.getString("create_date"),
+                        getAbusePicRes = this.jdbcTemplate.query(
+                                "SELECT picture_idx " +
+                                        "FROM picture " +
+                                        "WHERE pic_abuse_idx = ?;\n",
+                                (rk,rownum) -> new GetAbusePicRes(
+                                        rk.getInt("picture_idx")
+                                ),rs.getInt("abuse_idx")
+                        ),
+                        getAbuseVidRes = this.jdbcTemplate.query(
+                                "SELECT video_idx FROM video " +
+                                        "WHERE vid_abuse_idx = ?;\n",
+                                (rk,rownum) -> new GetAbuseVidRes(
+                                        rk.getInt("video_idx")
+                                ),rs.getInt("abuse_idx")
+                        ),
+                        getAbuseRecRes = this.jdbcTemplate.query(
+                                "SELECT recording_idx FROM recording " +
+                                        "WHERE rec_abuse_idx = ?;\n",
+                                (rk,rownum) -> new GetAbuseRecRes(
+                                        rk.getInt("recording_idx")
+                                ),rs.getInt("abuse_idx")
+                        ),
                         getAbuseSuspectRes = this.jdbcTemplate.query(
                                 "SELECT s.suspect_name, s.suspect_gender, s.suspect_age, s.suspect_address " +
                                         "FROM suspect as s join situation_suspect_relation as ss on ss.suspect_idx_relation = s.suspect_idx\n" +
@@ -74,7 +101,9 @@ public class AbuseDao {
                                         rk.getString("suspect_gender"),
                                         rk.getString("suspect_age"),
                                         rk.getString("suspect_address")
-                                ),rs.getInt("abuse_idx"))),getAbuseByIdxParams);
+                                ),rs.getInt("abuse_idx")
+                        )
+                ),getAbuseByIdxParams);
     }
 
 

--- a/src/main/java/com/save_backend/src/abuse/AbuseDao.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseDao.java
@@ -1,12 +1,7 @@
 package com.save_backend.src.abuse;
 
 import com.save_backend.src.abuse.model.*;
-import com.save_backend.src.child.model.PatchChildDelRes;
-import com.save_backend.src.child.model.PatchChildEditReq;
-import com.save_backend.src.child.model.PatchChildEditRes;
-import com.save_backend.src.suspect.model.GetSuspectRes;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -108,6 +103,26 @@ public class AbuseDao {
         };
 
         return this.jdbcTemplate.update(modifyAbuseQuery, modifyAbuseParams);
+    }
+
+    public void deleteAbuseSuspect(int abuseIdx) {
+        String deleteAbuseSuspectQuery = "delete from situation_suspect_relation where abuse_idx_relation = ?";
+        int deleteAbuseParam = abuseIdx;
+
+        this.jdbcTemplate.update(deleteAbuseSuspectQuery, deleteAbuseParam);
+    }
+
+    public int modifyAbuseSuspect(int abuseIdx, PatchAbuseSuspectReq patchAbuseSuspectReq) {
+        String modifyAbuseSuspectQuery = "insert into situation_suspect_relation(abuse_idx_relation, suspect_idx_relation) " +
+                "VALUES (?, ?)";
+        Object[] modifyAbuseSuspectParams = new Object[]{
+                abuseIdx,
+                patchAbuseSuspectReq.getSuspectIdx()
+        };
+        this.jdbcTemplate.update(modifyAbuseSuspectQuery, modifyAbuseSuspectParams);
+
+        String lastInserIdQuery = "select last_insert_id()";
+        return this.jdbcTemplate.queryForObject(lastInserIdQuery,int.class);
     }
 
 

--- a/src/main/java/com/save_backend/src/abuse/AbuseDao.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseDao.java
@@ -1,6 +1,7 @@
 package com.save_backend.src.abuse;
 
 import com.save_backend.src.abuse.model.*;
+import com.save_backend.src.child.model.PatchChildDelRes;
 import com.save_backend.src.child.model.PatchChildEditReq;
 import com.save_backend.src.child.model.PatchChildEditRes;
 import com.save_backend.src.suspect.model.GetSuspectRes;
@@ -107,6 +108,30 @@ public class AbuseDao {
         };
 
         return this.jdbcTemplate.update(modifyAbuseQuery, modifyAbuseParams);
+    }
+
+
+    public PatchAbuseDelRes deleteAbuse(int abuseIdx) {
+
+        String getAbuseByIdxQuery =
+                "SELECT abuse_date, abuse_time, abuse_place, abuse_type, detail_description, etc\n" +
+                        "FROM abuse_situation WHERE abuse_idx = ?;";
+
+        String deleteAbuseQuery = "update abuse_situation set status = 'INACTIVE' where abuse_idx = ?";
+        int deleteAbuseParam = abuseIdx;
+
+        this.jdbcTemplate.update(deleteAbuseQuery, deleteAbuseParam);
+
+        return this.jdbcTemplate.queryForObject(getAbuseByIdxQuery,
+                (rs, rowNum) -> new PatchAbuseDelRes(
+                        rs.getString("abuse_date"),
+                        rs.getString("abuse_time"),
+                        rs.getString("abuse_place"),
+                        rs.getString("abuse_type"),
+                        rs.getString("detail_description"),
+                        rs.getString("etc"),
+                        "학대 정황 삭제가 완료되었습니다."
+                ), deleteAbuseParam);
     }
 
 

--- a/src/main/java/com/save_backend/src/abuse/AbuseDao.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseDao.java
@@ -82,6 +82,34 @@ public class AbuseDao {
     }
 
 
+    public int modifyAbuse(PatchAbuseReq patchAbuseReq, int abuseIdx){
+        //학대 유형 list -> string 변환
+        List<String> type = patchAbuseReq.getType();
+        StringBuilder sb = new StringBuilder();
+        for (String s : type) {
+            sb.append(s);
+            sb.append(",");
+        }
+        String typeStr = sb.toString();
+
+        String modifyAbuseQuery = "UPDATE abuse_situation " +
+                "SET abuse_date = ?, abuse_time = ?, abuse_place = ?, abuse_type = ?, detail_description = ?, etc = ?, edit_date = current_date\n" +
+                "WHERE abuse_idx = ?;";
+
+        Object[] modifyAbuseParams = new Object[]{
+                patchAbuseReq.getDate(),
+                patchAbuseReq.getTime(),
+                patchAbuseReq.getPlace(),
+                typeStr,
+                patchAbuseReq.getDetail(),
+                patchAbuseReq.getEtc(),
+                abuseIdx
+        };
+
+        return this.jdbcTemplate.update(modifyAbuseQuery, modifyAbuseParams);
+    }
+
+
     /**
      * Validation
      */

--- a/src/main/java/com/save_backend/src/abuse/AbuseProvider.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseProvider.java
@@ -2,7 +2,9 @@ package com.save_backend.src.abuse;
 
 import com.save_backend.config.exception.BaseException;
 import com.save_backend.src.abuse.model.GetAbuseRes;
+import com.save_backend.src.abuse.model.PatchAbuseSuspectReq;
 import com.save_backend.src.abuse.model.PostAbuseSuspectReq;
+import com.save_backend.src.suspect.model.PatchSuspectReq;
 import org.springframework.stereotype.Service;
 
 import static com.save_backend.config.response.BaseResponseStatus.*;
@@ -41,7 +43,7 @@ public class AbuseProvider {
             throw new BaseException(DATABASE_ERROR);
         }
     }
-    public int checkSuspect(int suspectIdx) throws BaseException {
+    public int checkSuspect(PatchAbuseSuspectReq suspectIdx) throws BaseException {
         try{
             return abuseDao.checkSuspect(suspectIdx);
         } catch (Exception exception) {

--- a/src/main/java/com/save_backend/src/abuse/AbuseProvider.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseProvider.java
@@ -2,8 +2,7 @@ package com.save_backend.src.abuse;
 
 import com.save_backend.config.exception.BaseException;
 import com.save_backend.src.abuse.model.GetAbuseRes;
-import com.save_backend.src.child.ChildDao;
-import com.save_backend.src.suspect.model.GetSuspectRes;
+import com.save_backend.src.abuse.model.PostAbuseSuspectReq;
 import org.springframework.stereotype.Service;
 
 import static com.save_backend.config.response.BaseResponseStatus.*;

--- a/src/main/java/com/save_backend/src/abuse/AbuseService.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseService.java
@@ -58,7 +58,7 @@ public class AbuseService {
      */
     public void modifyAbuse(int abuseIdx, PatchAbuseReq patchAbuseReq) throws BaseException {
         //존재하는 정황(active)에 대한 modify인지 확인
-        if(abuseProvider.checkChild(abuseIdx) ==0) {
+        if(abuseProvider.checkAbuse(abuseIdx) ==0) {
             throw new BaseException(NOT_EXIST_ABUSE_SITUATION);
         }
 

--- a/src/main/java/com/save_backend/src/abuse/AbuseService.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseService.java
@@ -62,6 +62,13 @@ public class AbuseService {
             throw new BaseException(NOT_EXIST_ABUSE_SITUATION);
         }
 
+        //의심자가 존재(active)하는지 확인
+        for(int i = 0; i < patchAbuseReq.getSuspect().size(); i++) {
+            if(abuseProvider.checkSuspect(patchAbuseReq.getSuspect().get(i))==0){
+                throw new BaseException(NOT_EXIST_SUSPECT);
+            }
+        }
+
         try{
             int editResult = abuseDao.modifyAbuse(patchAbuseReq, abuseIdx);
             if(editResult == 0){
@@ -77,7 +84,6 @@ public class AbuseService {
             }
 
         } catch (Exception exception) {
-            System.out.println("exception = " + exception);
             throw new BaseException(DATABASE_ERROR);
         }
     }

--- a/src/main/java/com/save_backend/src/abuse/AbuseService.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseService.java
@@ -1,6 +1,7 @@
 package com.save_backend.src.abuse;
 
 import com.save_backend.config.exception.BaseException;
+import com.save_backend.src.abuse.model.PatchAbuseReq;
 import com.save_backend.src.abuse.model.PostAbuseReq;
 import com.save_backend.src.abuse.model.PostAbuseRes;
 import org.springframework.stereotype.Service;
@@ -54,4 +55,22 @@ public class AbuseService {
     }
 
 
+    /**
+     * 3. 학대 정황 수정
+     */
+    public void modifyAbuse(int abuseIdx, PatchAbuseReq patchAbuseReq) throws BaseException {
+        //존재하는 정황(active)에 대한 modify인지 확인
+        if(abuseProvider.checkChild(abuseIdx) ==0) {
+            throw new BaseException(NOT_EXIST_ABUSE_SITUATION);
+        }
+        try{
+            int editResult = abuseDao.modifyAbuse(patchAbuseReq, abuseIdx);
+            if(editResult == 0){
+                throw new BaseException(MODIFY_FAIL_POST);
+            }
+        } catch (Exception exception) {
+            System.out.println("exception = " + exception);
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/save_backend/src/abuse/AbuseService.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseService.java
@@ -1,9 +1,11 @@
 package com.save_backend.src.abuse;
 
 import com.save_backend.config.exception.BaseException;
+import com.save_backend.src.abuse.model.PatchAbuseDelRes;
 import com.save_backend.src.abuse.model.PatchAbuseReq;
 import com.save_backend.src.abuse.model.PostAbuseReq;
 import com.save_backend.src.abuse.model.PostAbuseRes;
+import com.save_backend.src.child.model.PatchChildDelRes;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -70,6 +72,22 @@ public class AbuseService {
             }
         } catch (Exception exception) {
             System.out.println("exception = " + exception);
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+
+    /**
+     * 4. 학대 정황 삭제 (active -> inactive)
+     */
+    public PatchAbuseDelRes deleteAbuse(int abuseIdx) throws BaseException {
+        //존재하는 정황(active)에 대한 delete인지 확인
+        if(abuseProvider.checkAbuse(abuseIdx)==0){
+            throw new BaseException(NOT_EXIST_ABUSE_SITUATION);
+        }
+        try{
+            return abuseDao.deleteAbuse(abuseIdx);
+        }catch(Exception exception){
             throw new BaseException(DATABASE_ERROR);
         }
     }

--- a/src/main/java/com/save_backend/src/abuse/AbuseService.java
+++ b/src/main/java/com/save_backend/src/abuse/AbuseService.java
@@ -30,10 +30,6 @@ public class AbuseService {
         if(abuseProvider.checkChild(postAbuseReq.getChildIdx())==0){
             throw new BaseException(NOT_EXIST_CHILD);
         }
-        //학대 의심자 존재하는지 확인
-        if(abuseProvider.checkSuspect(postAbuseReq.getChildIdx())==0){
-            throw new BaseException(NOT_EXIST_SUSPECT);
-        }
         try{
             //학대 유형 list -> string 변환
             List<String> type = postAbuseReq.getType();
@@ -65,11 +61,21 @@ public class AbuseService {
         if(abuseProvider.checkChild(abuseIdx) ==0) {
             throw new BaseException(NOT_EXIST_ABUSE_SITUATION);
         }
+
         try{
             int editResult = abuseDao.modifyAbuse(patchAbuseReq, abuseIdx);
             if(editResult == 0){
                 throw new BaseException(MODIFY_FAIL_POST);
             }
+
+            //학대-의심자 테이블에서 abuseIdx 일치하는 값 삭제 후 수정 진행
+            abuseDao.deleteAbuseSuspect(abuseIdx);
+
+            //학대정황-의심자 테이블 수정(추가)
+            for(int i = 0; i < patchAbuseReq.getSuspect().size(); i++) {
+                abuseDao.modifyAbuseSuspect(abuseIdx, patchAbuseReq.getSuspect().get(i));
+            }
+
         } catch (Exception exception) {
             System.out.println("exception = " + exception);
             throw new BaseException(DATABASE_ERROR);

--- a/src/main/java/com/save_backend/src/abuse/model/GetAbusePicRes.java
+++ b/src/main/java/com/save_backend/src/abuse/model/GetAbusePicRes.java
@@ -1,0 +1,12 @@
+package com.save_backend.src.abuse.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GetAbusePicRes {
+    private int pictureIdx;
+}

--- a/src/main/java/com/save_backend/src/abuse/model/GetAbuseRecRes.java
+++ b/src/main/java/com/save_backend/src/abuse/model/GetAbuseRecRes.java
@@ -1,0 +1,12 @@
+package com.save_backend.src.abuse.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GetAbuseRecRes {
+    private int recordIdx;
+}

--- a/src/main/java/com/save_backend/src/abuse/model/GetAbuseRes.java
+++ b/src/main/java/com/save_backend/src/abuse/model/GetAbuseRes.java
@@ -18,5 +18,9 @@ public class GetAbuseRes {
     private String type;
     private String detail;
     private String etc;
+    private String createdAt;
+    private List<GetAbusePicRes> pictureIdx;
+    private List<GetAbuseVidRes>  videoIdx;
+    private List<GetAbuseRecRes> recordingIdx;
     private List<GetAbuseSuspectRes> suspect;
 }

--- a/src/main/java/com/save_backend/src/abuse/model/GetAbuseVidRes.java
+++ b/src/main/java/com/save_backend/src/abuse/model/GetAbuseVidRes.java
@@ -1,0 +1,12 @@
+package com.save_backend.src.abuse.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GetAbuseVidRes {
+    private int videoIdx;
+}

--- a/src/main/java/com/save_backend/src/abuse/model/PatchAbuseDelRes.java
+++ b/src/main/java/com/save_backend/src/abuse/model/PatchAbuseDelRes.java
@@ -1,0 +1,20 @@
+package com.save_backend.src.abuse.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PatchAbuseDelRes {
+    private String date;
+    private String time;
+    private String place;
+    private String type;
+    private String detail;
+    private String etc;
+    private String deleteAbuse;
+}

--- a/src/main/java/com/save_backend/src/abuse/model/PatchAbuseReq.java
+++ b/src/main/java/com/save_backend/src/abuse/model/PatchAbuseReq.java
@@ -1,0 +1,19 @@
+package com.save_backend.src.abuse.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PatchAbuseReq {
+    private String date;
+    private String time;
+    private String place;
+    private String detail;
+    private String etc;  //선택
+    private List<String> type;
+}

--- a/src/main/java/com/save_backend/src/abuse/model/PatchAbuseReq.java
+++ b/src/main/java/com/save_backend/src/abuse/model/PatchAbuseReq.java
@@ -16,4 +16,5 @@ public class PatchAbuseReq {
     private String detail;
     private String etc;  //선택
     private List<String> type;
+    private List<PatchAbuseSuspectReq> suspect;
 }

--- a/src/main/java/com/save_backend/src/abuse/model/PatchAbuseSuspectReq.java
+++ b/src/main/java/com/save_backend/src/abuse/model/PatchAbuseSuspectReq.java
@@ -1,0 +1,12 @@
+package com.save_backend.src.abuse.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PatchAbuseSuspectReq {
+    private int suspectIdx;
+}


### PR DESCRIPTION
1. 학대 정황 수정 api
- 학대 기록에 따른 학대 의심자를 수정하는 것은 학대의심자-학대정황 테이블에서 항목 삭제후 새로운 학대 의심자를 추가(업데이트) 하는 방식으로 구현
2. 학대 정황 삭제 api
